### PR TITLE
Update TableComponent.tsx to use `deepClone` function over spread.

### DIFF
--- a/src/TableComponent.tsx
+++ b/src/TableComponent.tsx
@@ -56,7 +56,7 @@ const TableComponent: FunctionComponent<RootProps> = (props) => {
   };
 
   const addRows = (count: number = 1) => {
-    const newValue = { ...value };
+    const newValue = deepClone(value);
     // Calculate the column count from the first row
     const columnCount = value.rows[0].cells.length;
     for (let i = 0; i < count; i++) {
@@ -71,7 +71,7 @@ const TableComponent: FunctionComponent<RootProps> = (props) => {
   };
 
   const addRowAt = (index: number = 0) => {
-    const newValue = { ...value };
+    const newValue = deepClone(value);
     // Calculate the column count from the first row
     const columnCount = value.rows[0].cells.length;
 


### PR DESCRIPTION
When using the table within a block editor, having created a table, left the document and returned, adding a new row/s would result in a `Cannot add property x, object is not extensible` error in the console.

Both the `addRows` and `addRowAt` functions were using spread syntax when assigning the `newValue` const, rather than using the `deepClone` function which is used by all other functions, resulting in the error.

Switching to the `deepClone` function has resolved this issue.